### PR TITLE
feat: verify-token 時に `read:basic_info` scope あれば基本的な情報を渡す

### DIFF
--- a/webapp/api/oauth/verifyToken.ts
+++ b/webapp/api/oauth/verifyToken.ts
@@ -1,8 +1,10 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
-import { HonoEnv } from 'load-context'
-import { IUserInfo } from 'repository/idp'
 import { z } from 'zod'
+
+import { readScope } from '../../constants/scope'
+import { HonoEnv } from '../../load-context'
+import { IUserInfo } from '../../repository/idp'
 
 const app = new Hono<HonoEnv>()
 
@@ -89,7 +91,7 @@ app.post(
       scopes: tokenInfo.scopes.map(s => s.scope.name),
     }
 
-    if (res.scopes.includes('read:basic_info')) {
+    if (res.scopes.includes(readScope.basic_info)) {
       const user = await c.var.idpClient.findUserById(res.user_id)
       if (user) res.user_info = user
     }

--- a/webapp/api/oauth/verifyToken.ts
+++ b/webapp/api/oauth/verifyToken.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { readScope } from '../../constants/scope'
+import { READ_SCOPES } from '../../constants/scope'
 import { HonoEnv } from '../../load-context'
 import { IUserInfo } from '../../repository/idp'
 
@@ -91,7 +91,7 @@ app.post(
       scopes: tokenInfo.scopes.map(s => s.scope.name),
     }
 
-    if (res.scopes.includes(readScope.basic_info)) {
+    if (res.scopes.includes(READ_SCOPES.BASIC_INFO)) {
       const user = await c.var.idpClient.findUserById(res.user_id)
       if (user) res.user_info = user
     }

--- a/webapp/constants/scope.ts
+++ b/webapp/constants/scope.ts
@@ -1,3 +1,3 @@
-export const readScope = {
-  basic_info: 'read:basic_info',
+export const READ_SCOPES = {
+  BASIC_INFO: 'read:basic_info',
 }

--- a/webapp/constants/scope.ts
+++ b/webapp/constants/scope.ts
@@ -1,0 +1,3 @@
+export const readScope = {
+  basic_info: 'read:basic_info',
+}

--- a/webapp/db/seed.sql
+++ b/webapp/db/seed.sql
@@ -2,3 +2,5 @@
 -- https://orm.drizzle.team/docs/kit-seed-data
 
 INSERT OR IGNORE INTO `oauth_provider` (`id`, `name`) VALUES (1, "GitHub")
+
+INSERT OR IGNORE INTO `scope` (`id`, `name`, `description`) VALUES (1, "read:basic_info", "あなたのユーザー名やユーザー ID、プロフィール画像を読み取ります。")

--- a/webapp/repository/idp.ts
+++ b/webapp/repository/idp.ts
@@ -1,10 +1,11 @@
+/* eslint-disable sort-exports/sort-exports */
 // saitamau-maximum/id の db/schema.ts 参照
-interface IUserInfo {
+export interface IUserInfo {
   id: string
   display_name: string
   profile_image_url: string | null
 }
-interface IOauthConnection {
+export interface IOauthConnection {
   user_id: string
   provider_id: number
   provider_user_id: string


### PR DESCRIPTION
API 作るのも考えたけどまあ基本的な情報はこっちでいいかなと

これで
- Private Website が OAuth 対応できる
- → Pages から Workers に移行できる
- → `@saitamau-maximum/auth` を deprecated できる